### PR TITLE
Fix: Respect user-configured minimum fan speed in ipmitool implementation

### DIFF
--- a/ipmi_fan_control/__init__.py
+++ b/ipmi_fan_control/__init__.py
@@ -1,3 +1,3 @@
 """IPMI Fan Control - Manage server fan speeds using IPMI."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/ipmi_fan_control/__init__.py
+++ b/ipmi_fan_control/__init__.py
@@ -1,3 +1,3 @@
 """IPMI Fan Control - Manage server fan speeds using IPMI."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"

--- a/ipmi_fan_control/ipmitool.py
+++ b/ipmi_fan_control/ipmitool.py
@@ -411,8 +411,8 @@ class DellIPMIToolFanController:
                 else:
                     fan_speed = int(computed_speed)
                 
-                # Validate fan speed within safe range
-                fan_speed = max(min(fan_speed, 100), 30)  # Clamp between 30% and 100%
+                # Validate fan speed within configured PID controller range
+                fan_speed = max(min(fan_speed, self.pid.output_max), self.pid.output_min)
                 
                 # Set fan speed
                 self.set_fan_speed(fan_speed)


### PR DESCRIPTION
## Summary
- Removed hardcoded 30% minimum fan speed clamp in ipmitool implementation
- Now properly uses the PID controller's configured output limits
- Allows users to set fan speeds below 30% as requested

## Test plan
- [x] Test with IPMI_PID_MIN_SPEED set to various values (5%, 20%, 30%)
- [x] Verify fan speeds can go below 30% when temperature is below target
- [x] Confirm PID controller respects configured min/max limits
- [x] Test that existing behavior is preserved when min is set to 30%
- [x] Tested by @rfleuryleveso on Dell R620 - confirmed fix works

Fixes #1